### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/ezzybot/__init__.py
+++ b/ezzybot/__init__.py
@@ -85,7 +85,7 @@ class bot(object):
     def run_plugin(self, function, plugin_wrapper, channel, info):
         try:
             self.output =function(info=info, conn=plugin_wrapper)
-            if self.output != None:
+            if self.output is not None:
                 if channel.startswith("#"):
                     plugin_wrapper.msg(channel,"[{}] {}".format(info['nick'], str(self.output)))
                 else:
@@ -229,7 +229,7 @@ class bot(object):
                     if self.regex != []:
                         for search in self.regex:
                             searched = re.search(search['regex'], irc_msg)
-                            if searched != None:
+                            if searched is not None:
                                 self.info = {"raw": irc_msg, "regex": search['regex'], "split": irc_msg.split(" "), "result": searched}
                                 self.plugin_wrapper=wrappers.connection_wrapper(self.irc, config, self.config_flood_protection, self)
                                 trigger_thread= Thread(target=self.run_trigger, args=(search['function'], self.plugin_wrapper,self.info,))

--- a/ezzybot/logging.py
+++ b/ezzybot/logging.py
@@ -34,7 +34,7 @@ class Logging(object):
         
     def search(self,time1,time2=None):
         time1 = time1.replace("]["," ").replace("]","").replace("[","")
-        if time2 != None:
+        if time2 is not None:
             time2 = time2.replace("]["," ").replace("]","").replace("[","")
 
         FMT = '%m/%d/%Y %H:%M:%S'
@@ -42,7 +42,7 @@ class Logging(object):
         for key in self.localEvents:
             tdelta = datetime.strptime(time1, FMT) - datetime.strptime( key.replace("]["," ").replace("]","").replace("[","") , FMT)
             if tdelta.total_seconds() > 0:
-                if time2 != None:
+                if time2 is not None:
                     dif2 = datetime.strptime(time2, FMT) - datetime.strptime( key.replace("]["," ").replace("]","").replace("[","") , FMT)
                     if dif2.total_seconds() < 0:
                         returned.append(self.localEvents[key])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ezzybot:ezzybot?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:ezzybot:ezzybot?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)